### PR TITLE
fix: distance calculation — return leg base & final trip

### DIFF
--- a/create-stats.js
+++ b/create-stats.js
@@ -34,13 +34,19 @@ function calculateDistance(trips) {
     const previousTrip = trips[i - 1];
 
     if (previousTrip && trip.isNewTrip) {
-      result += getPreciseDistance(getBaseCityCoordinates(trip.date), {
-        latitude: previousTrip.lat,
-        longitude: previousTrip.long,
-      });
+      // Return leg: previousTrip → home base
+      // Use previous trip's date to determine home base (where you departed from)
+      result += getPreciseDistance(
+        getBaseCityCoordinates(previousTrip.date),
+        {
+          latitude: previousTrip.lat,
+          longitude: previousTrip.long,
+        }
+      );
     }
 
     if (trip.isNewTrip) {
+      // Outbound leg: home base → current trip
       result += getPreciseDistance(getBaseCityCoordinates(trip.date), {
         latitude: trip.lat,
         longitude: trip.long,
@@ -51,6 +57,18 @@ function calculateDistance(trips) {
         { latitude: trip.lat, longitude: trip.long }
       );
     }
+  }
+
+  // Final return leg: last trip → home base
+  const lastTrip = trips[trips.length - 1];
+  if (lastTrip) {
+    result += getPreciseDistance(
+      getBaseCityCoordinates(lastTrip.date),
+      {
+        latitude: lastTrip.lat,
+        longitude: lastTrip.long,
+      }
+    );
   }
 
   return Math.round(result / 1000);

--- a/create-stats.js
+++ b/create-stats.js
@@ -35,14 +35,13 @@ function calculateDistance(trips) {
 
     if (previousTrip && trip.isNewTrip) {
       // Return leg: previousTrip → home base
-      // Use previous trip's date to determine home base (where you departed from)
-      result += getPreciseDistance(
-        getBaseCityCoordinates(previousTrip.date),
-        {
-          latitude: previousTrip.lat,
-          longitude: previousTrip.long,
-        }
-      );
+      // Use current trip's date so relocations are implicitly modeled:
+      // e.g. Paris→Stockholm transition uses Stockholm base (1547 km),
+      // which is the actual relocation path, not Paris→Kazan (3211 km).
+      result += getPreciseDistance(getBaseCityCoordinates(trip.date), {
+        latitude: previousTrip.lat,
+        longitude: previousTrip.long,
+      });
     }
 
     if (trip.isNewTrip) {

--- a/create-stats.test.js
+++ b/create-stats.test.js
@@ -70,7 +70,7 @@ describe("Create statistics", () => {
     const { totalDistanceKm } = createStats(data);
 
     // got similar results when calculating by hand
-    expect(totalDistanceKm).toEqual(18807);
+    expect(totalDistanceKm).toEqual(17662);
   });
 
   it("should calculate days stats correctly", () => {

--- a/create-stats.test.js
+++ b/create-stats.test.js
@@ -70,7 +70,7 @@ describe("Create statistics", () => {
     const { totalDistanceKm } = createStats(data);
 
     // got similar results when calculating by hand
-    expect(totalDistanceKm).toEqual(17598);
+    expect(totalDistanceKm).toEqual(18807);
   });
 
   it("should calculate days stats correctly", () => {

--- a/data.js
+++ b/data.js
@@ -628,6 +628,14 @@ export const TRIPS = [
     long: 7.3618,
   },
   {
+    countryId: "250",
+    city: "Montpellier",
+    date: "09-09-2021",
+    lat: 43.6107,
+    long: 3.8767,
+    isNewTrip: true,
+  },
+  {
     countryId: "352",
     city: "Luxembourg",
     date: "18-09-2021",
@@ -641,14 +649,6 @@ export const TRIPS = [
     date: "25-09-2021",
     lat: 50.8729,
     long: 4.3093,
-    isNewTrip: true,
-  },
-  {
-    countryId: "250",
-    city: "Montpellier",
-    date: "09-09-2021",
-    lat: 43.6107,
-    long: 3.8767,
     isNewTrip: true,
   },
 


### PR DESCRIPTION
## Bug fixes

### 1. Final return leg never counted (`create-stats.js`)
The last trip (Funchal) has no following `isNewTrip`, so the Funchal→Paris return leg (2,411 km) was never added.

**Fix:** Add a final return calculation after the loop.

### 2. Montpellier out of chronological order (`data.js`)
Montpellier `09-09-2021` was listed after Brussels `25-09-2021`. Moved it before Luxembourg and Brussels.

### Not changed: return leg base selection
Initially tried switching from `trip.date` to `previousTrip.date` for the return leg home base. **Reverted** because `trip.date` implicitly models relocations correctly:
- Paris→Stockholm transition: Stockholm base = 1,547 km (actual move) vs Kazan base = 3,211 km (wrong)
- Kazan→Paris transition: Paris base = 3,211 km (actual move) vs Stockholm base = 1,877 km (wrong)

## Impact
- **Before:** 293,805 km
- **After:** 296,216 km (+2,411 km — final return leg only)

## Tests
- All 4 unit tests pass (updated expected distance 17,598 → 17,662)
- Chronological order verified: 0 out-of-order entries